### PR TITLE
added 202 to the allowed return codes of play api call

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -127,7 +127,7 @@ module.exports = NodeHelper.create({
 
             if (noti == "PLAY") {
                 this.spotify.play(payload, (code, error, result) => {
-                    if (code !== 204) {
+                    if ((code !== 204) && (code !== 202)){
                         console.log(error)
                         return
                     }


### PR DESCRIPTION
It looks like spotify sends an 202 return code if the play api is called. As a result without the change an null is printed to the console and the "DONE_PLAY" notification is not send. I need this notification to react in one of my other modules.