### PR TITLE
Feature/offline account switch

### DIFF
--- a/MMM-Spotify.css
+++ b/MMM-Spotify.css
@@ -20,7 +20,6 @@
 }
 
 #SPOTIFY.inactive {
-  display:none;
 }
 
 #SPOTIFY_BACKGROUND {
@@ -83,11 +82,14 @@
   width: calc(var(--sp-width) - 40px);
   height: calc(var(--sp-width) - 40px);
   margin-bottom:0.5vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 #SPOTIFY_COVER_IMAGE {
-  width:100%;
-  height:100%;
+  max-width:100%;
+  max-height:100%;
   border-radius:10px;
   box-shadow:black 1px 1px 1px 1px;
 }
@@ -161,8 +163,7 @@ progress[value]#SPOTIFY_PROGRESS_BAR::-webkit-progress-bar {
 }
 
 #SPOTIFY_MODAL {
-  position: relative;
-  transform: translateY(-100%);
+  position: absolute;
   width: inherit;
   height: inherit;
 }
@@ -202,12 +203,6 @@ progress[value]#SPOTIFY_PROGRESS_BAR::-webkit-progress-bar {
 #SPOTIFY_MODAL_LIST {
   background: rgba(0,0,0);
   border-radius: 6px;
-}
-
-
-/* control "hidden" */
-#SPOTIFY.hidden #SPOTIFY_CONTROL{
-  display:none;
 }
 
 /* style "mini" */
@@ -258,12 +253,20 @@ progress[value]#SPOTIFY_PROGRESS_BAR::-webkit-progress-bar {
   width:calc(var(--sp-width) - 240px);
 }
 
-#SPOTIFY.noPlayback #SPOTIFY_FOREGROUND > * {
-  display:none;
+#SPOTIFY.inactive #SPOTIFY_MISC > * {
+  display: none;
 }
 
-#SPOTIFY.noPlayback #SPOTIFY_FOREGROUND #SPOTIFY_COVER {
-  display:block;
+#SPOTIFY.inactive #SPOTIFY_MISC > #SPOTIFY_CONTROL {
+  display: flex;
+}
+
+#SPOTIFY.inactive #SPOTIFY_CONTROL > * {
+  display: none;
+}
+
+#SPOTIFY.inactive #SPOTIFY_CONTROL > #SPOTIFY_CONTROL_ACCOUNTS {
+  display: block;
 }
 
 /* style "minimalistBar" */

--- a/README.md
+++ b/README.md
@@ -288,6 +288,14 @@ It can be used with MMM-pages for example (for show or hide the module)
 
 ## Update History
 
+---
+
+**INFO**
+
+Will start using the github `releases` function as an update history. The below list is only for historical reasons.
+
+---
+
 ### 1.6.3 (2020-11-05)
 
 - Fixed: reverted play / paused icons

--- a/node_helper.js
+++ b/node_helper.js
@@ -149,6 +149,7 @@ module.exports = NodeHelper.create({
   socketNotificationReceived: function (noti, payload) {
     if (noti == "INIT") {
       this.initAfterLoading(payload)
+      this.socketNotificationReceived("GET_ACCOUNTS")
       this.sendSocketNotification("INITIALIZED")
       return
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "MMM-Spotify",
-  "version": "1.6.3",
+  "version": "2.0.0",
   "description": "MM module for Spotify",
   "main": "MMM-Spotify.js",
   "keywords": [


### PR DESCRIPTION
- major changes to css - possible breaking changes for `miniBar` design
- changed behaviour of modul: always show spotify logo if nothing is playing (and the "pause timeout" has been triggered)
- reworked cover image loading
- added account switch button to "offline" view, so you can switch if nothing is playing