### PR TITLE
renamed accountDefault setting

### DIFF
--- a/MMM-Spotify.js
+++ b/MMM-Spotify.js
@@ -16,7 +16,7 @@ Module.register("MMM-Spotify", {
     useExternalModal: false, // if you want to use MMM-Modal for account and device popup selection instead of the build-in one (which is restricted to the album image size)
     updateInterval: 1000,
     idleInterval: 10000,
-    accountDefault: 0, // default account number, attention : 0 is the first account
+    defaultAccount: 0, // default account number, attention : 0 is the first account
     defaultDevice: null, // optional - if you want the "SPOTIFY_PLAY" notification to also work from "idle" status, you have to define your default device here (by name)
     allowDevices: [],
     iconify: "https://code.iconify.design/1/1.0.6/iconify.min.js",
@@ -66,7 +66,7 @@ Module.register("MMM-Spotify", {
     this.timer = null
     this.ads = false
     this.volume = 50
-    this.currentAccount = this.config.accountDefault
+    this.currentAccount = ((typeof this.config.accountDefault !== "undefined") ? this.config.accountDefault : this.config.defaultAccount) // check against both config settings for backwards compatibility since changes in version 2.0.2
     this.devices = []
     this.accounts = []
     this.externalModal = null

--- a/README.md
+++ b/README.md
@@ -135,12 +135,12 @@ That's all. `token.json` will be created, if success.
     showAccountButton: true, // if you want to show the "switch account" control button
     showDeviceButton: true, // if you want to show the "switch device" control button
     useExternalModal: false, // if you want to use MMM-Modal for account and device popup selection instead of the build-in one (which is restricted to the album image size)
-    accountDefault: 0, // default account number, attention : 0 is the first account
     updateInterval: 1000, // update interval when playing
     idleInterval: 30000, // update interval on idle
-    onStart: null, // disable onStart feature with `null`
-    deviceDisplay: "Listening on", // text to display in the device block (default style only)
+    defaultAccount: 0, // default account number, attention : 0 is the first account
+    defaultDevice: null, // optional - if you want the "SPOTIFY_PLAY" notification to also work from "idle" status, you have to define your default device here (by name)
     allowDevices: [], //If you want to limit devices to display info, use this. f.e. allowDevices: ["RASPOTIFY", "My Home speaker"],
+    onStart: null, // disable onStart feature with `null`
     // if you want to send custom notifications when suspending the module, f.e. switch MMM-Touch to a different "mode"
     notificationsOnSuspend: [
       {
@@ -159,6 +159,7 @@ That's all. `token.json` will be created, if success.
         payload: "mySpotifyControlMode",
       },
     ],
+    deviceDisplay: "Listening on", // text to display in the device block (default style only)
     volumeSteps: 5, // in percent, the steps you want to increase or decrese volume when reacting on the "SPOTIFY_VOLUME_{UP,DOWN}" notifications
     miniBarConfig: {
       album: true, // display Album name in miniBar style

--- a/node_helper.js
+++ b/node_helper.js
@@ -42,7 +42,7 @@ module.exports = NodeHelper.create({
     this.suspended = false
     this.config = config
     if (!account) {
-      account = this.config.accountDefault
+      account = ((typeof this.config.accountDefault !== "undefined") ? this.config.accountDefault : this.config.defaultAccount) // check against both config settings for backwards compatibility since changes in version 2.0.2
       console.log("[SPOTIFY] MMM-Spotify Version:",  require('./package.json').version)
     }
     let file = path.resolve(__dirname, "spotify.config.json")


### PR DESCRIPTION
Quality of life changes:
- renamed `accountDefault` to `defaultAccount`
- synchronized README config list with current default config