### PR TITLE
Remove overloaded keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,6 @@
     "magicmirror",
     "magic mirror",
     "module",
-    "magicmirrormodule",
-    "magic mirror module",
     "spotify",
     "music"
   ],


### PR DESCRIPTION
Overloaded keywords are not optimal practice.

I noticed them because we display the keywords on [the new module list](https://kristjanesperanto.github.io/MagicMirror-3rd-Party-Modules/).