### PR TITLE
fix: adjust spotify callback URL to use loopback instead of localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You should be a premium member of Spotify
 1. Go to https://developer.spotify.com
 2. Navigate to **DASHBOARD** > **Create an app** (fill information as your thought)
 3. Setup the app created, (**EDIT SETTINGS**)
-   - Redirect URIs. : `http://localhost:8888/callback`
+   - Redirect URIs. : `http://127.0.0.1:8888/callback`
    - That's all you need. Just save it.
 4. Now copy your **Client ID** and **Client Secret** to any memo
 
@@ -124,6 +124,11 @@ Make sure that `TOKEN` is referencing different file names, as these files will 
 ```
 
 #### Custom callback
+
+**Update 2025:**  
+Spotify is [now enforcing HTTPS scheme usage][1] on apps, with the exception of the local loopback adress of `127.0.0.1`.  
+This breaks the custom callback URLs for the method described here. Currently, there is no fix in progress. If you feel like it, contribute one via PR!
+
 
 If you are running MagicMirror in an environment without UI (Docker f.e.), you need to provide a custom callback URL in your account file, which points to your devices IP address.  
 This can be configured inside the `spotify.config.json` file.
@@ -408,3 +413,7 @@ It can be used with MMM-pages for example (for show or hide the module)
 - Biggest thanks to @eouia for all his work and inspiration
 - Special thanks to @ejay-ibm so much for taking the time to cowork to make this module.
 - Thanks to @KamisamaPT for helping design
+
+
+<!-- Links -->
+[1]: <https://developer.spotify.com/blog/2025-02-12-increasing-the-security-requirements-for-integrating-with-spotify> "Increasing the security requirements for integrating with Spotify"

--- a/Spotify.js
+++ b/Spotify.js
@@ -14,7 +14,7 @@ class Spotify {
       USERNAME: "",
       CLIENT_ID: "",
       CLIENT_SECRET: "",
-      AUTH_DOMAIN: "http://localhost",
+      AUTH_DOMAIN: "http://127.0.0.1",
       AUTH_PATH: "/callback",
       AUTH_PORT: "8888",
       SCOPE: "user-read-private app-remote-control playlist-read-private streaming user-read-playback-state user-modify-playback-state",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mmm-spotify",
-  "version": "2.2.2",
+  "version": "2.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmm-spotify",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Spotify display and controller for MagicMirror²",
   "main": "MMM-Spotify.js",
   "keywords": [


### PR DESCRIPTION
- fix: adjust default value for callback host to use local loopback ip instead
- docs: update documentation and add hint of broken usage for custom callback URLs (with using containers f.e.)

This fixes #205 